### PR TITLE
Creating version.properties file automatically

### DIFF
--- a/src/main/groovy/org/moallemi/gradle/internal/VersionCodeOptions.groovy
+++ b/src/main/groovy/org/moallemi/gradle/internal/VersionCodeOptions.groovy
@@ -96,7 +96,12 @@ class VersionCodeOptions {
                 return code
 
             case VersionCodeType.AUTO_INCREMENT_ONE_STEP:
-                versionPropsFile = new File(project.buildFile.getParent() + "/version.properties")
+                versionPropsFile = new File("version.properties")
+                // Create version.properties file if necessary
+                if (!versionPropsFile.exists()) {
+                    versionPropsFile.createNewFile()
+                }
+
                 if (versionPropsFile.canRead()) {
                     def Properties versionProps = new Properties()
                     versionProps.load(new FileInputStream(versionPropsFile))

--- a/src/test/groovy/org/moallemi/gradle/VersionCodeTest.groovy
+++ b/src/test/groovy/org/moallemi/gradle/VersionCodeTest.groovy
@@ -62,20 +62,35 @@ public class VersionCodeTest {
         assertThat(versionCode).is(new SmallerThanCondition(Integer.MAX_VALUE))
     }
 
-//    @Test //TODO write test
-//    public void testAutoIncrementOneStep() throws Exception {
-//        project.advancedVersioning {
-//            codeOptions {
-//                versionCodeType VersionCodeType.AUTO_INCREMENT_ONE_STEP
-//            }
-//        }
-//        int versionCode = project.advancedVersioning.versionCode
-//        Reporter.log("versionCode :: AUTO_INCREMENT_ONE_STEP = " + versionCode, true);
-//        assertThat(versionCode).is(new SmallerThanCondition(Integer.MAX_VALUE))
-//    }
+    @Test
+    public void testAutoIncrementOneStep() {
+        int currentVersionCode = project.advancedVersioning.versionCode
+        project.advancedVersioning {
+            codeOptions {
+                versionCodeType VersionCodeType.AUTO_INCREMENT_ONE_STEP
+            }
+        }
+
+        assertThat(currentVersionCode).is(project.advancedVersioning.versionCode + 1)
+    }
+
+    @Test
+    public void testAutoCreatingVersionPropertiesFile() {
+        def versionFile = new File("version.properties")
+        versionFile.delete()
+
+        project.advancedVersioning {
+            codeOptions {
+                versionCodeType VersionCodeType.AUTO_INCREMENT_DATE
+            }
+        }
+
+        assertThat(versionFile.exists()).is(true)
+        assertThat(project.advancedVersioning.versionCode).is(1)
+    }
 
     class SmallerThanCondition extends Condition<Integer> {
-        
+
         private int first;
 
         public SmallerThanCondition(Integer first) {


### PR DESCRIPTION
Hi @moallemi , I found out that your plugin is very useful. I only found a small issue is that I have to add the file ```version.properties``` file manually when I want to use ```VersionCodeType.AUTO_INCREMENT_ONE_STEP```. 
I made a minor modification to create that file automatically if it doesn't exist.
I also added a test ```testAutoIncrementOneStep``` and wrote the test for ```testAutoIncrementOneStep```.
Please take a look when you have free time :)