### PR TITLE
Add support for version 2.x of the Android Gradle plugin

### DIFF
--- a/src/main/groovy/org/moallemi/gradle/AdvancedBuildVersionPlugin.groovy
+++ b/src/main/groovy/org/moallemi/gradle/AdvancedBuildVersionPlugin.groovy
@@ -44,7 +44,7 @@ class AdvancedBuildVersionPlugin implements Plugin<Project> {
         }
     }
 
-    private static final String[] SUPPORTED_ANDROID_VERSIONS = ['0.14.', '1.'];
+    private static final String[] SUPPORTED_ANDROID_VERSIONS = ['0.14.', '1.', '2.'];
 
     def static boolean checkAndroidVersion(String version) {
         for (String supportedVersion : SUPPORTED_ANDROID_VERSIONS) {


### PR DESCRIPTION
Without this, it's currently impossible to use the plugin with the Android Studio 1.5 preview