### PR TITLE
Add support for Android Gradle Plugin 4.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.70'
+    id 'org.jetbrains.kotlin.jvm' version '1.4.10'
     id "com.gradle.plugin-publish" version "0.10.1"
     id 'java-gradle-plugin'
 
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.70"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.10"
     implementation "com.android.tools.build:gradle:3.0.0"
     implementation "org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r"
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,7 +1,7 @@
 
 project.description = "Generate Android version code and version name automatically from git tags, date,... ."
 project.group = "me.moallemi.gradle"
-project.version = "1.7.1"
+project.version = "1.7.2"
 
 project.ext {
     pluginId = 'me.moallemi.advanced-build-version'

--- a/gradle/test-setup.gradle
+++ b/gradle/test-setup.gradle
@@ -8,6 +8,7 @@ compileTestKotlin {
 test {
     testLogging {
         events "passed", "skipped", "failed", "standardOut", "standardError"
+        exceptionFormat = 'full'
     }
 }
 

--- a/src/main/kotlin/me/moallemi/gradle/advancedbuildversion/AdvancedBuildVersionPlugin.kt
+++ b/src/main/kotlin/me/moallemi/gradle/advancedbuildversion/AdvancedBuildVersionPlugin.kt
@@ -23,6 +23,7 @@ import com.android.build.gradle.LibraryPlugin
 import me.moallemi.gradle.advancedbuildversion.gradleextensions.AdvancedBuildVersionConfig
 import me.moallemi.gradle.advancedbuildversion.utils.checkAndroidGradleVersion
 import me.moallemi.gradle.advancedbuildversion.utils.checkMinimumGradleVersion
+import me.moallemi.gradle.advancedbuildversion.utils.getAndroidPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.internal.impldep.org.eclipse.jgit.errors.NotSupportedException
@@ -53,8 +54,10 @@ class AdvancedBuildVersionPlugin : Plugin<Project> {
     private fun configureAndroid(project: Project, config: AdvancedBuildVersionConfig) {
         config.increaseVersionCodeIfPossible()
 
-        val appExtension = project.extensions.getByType(AppExtension::class.java)
-        config.renameOutputApkIfPossible(appExtension.applicationVariants)
+        if (getAndroidPlugin(project)?.version?.compareTo("4.1.0") == -1) { // versions prior to 4.1.0
+            val appExtension = project.extensions.getByType(AppExtension::class.java)
+            config.renameOutputApkIfPossible(appExtension.applicationVariants)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/AdvancedBuildVersionConfig.kt
+++ b/src/main/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/AdvancedBuildVersionConfig.kt
@@ -16,6 +16,7 @@
 
 package me.moallemi.gradle.advancedbuildversion.gradleextensions
 
+import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApplicationVariant
 import groovy.lang.Closure
 import me.moallemi.gradle.advancedbuildversion.utils.GitWrapper
@@ -56,5 +57,11 @@ open class AdvancedBuildVersionConfig(private val project: Project) {
 
     fun renameOutputApkIfPossible(variants: DomainObjectSet<ApplicationVariant>) {
         outputConfig.renameOutputApkIfPossible(variants)
+    }
+
+    fun renameOutputApk() {
+        project.extensions.findByType(AppExtension::class.java)?.run {
+            outputConfig.renameOutputApkIfPossible(applicationVariants)
+        }
     }
 }

--- a/src/main/kotlin/me/moallemi/gradle/advancedbuildversion/utils/CompatibilityManager.kt
+++ b/src/main/kotlin/me/moallemi/gradle/advancedbuildversion/utils/CompatibilityManager.kt
@@ -22,7 +22,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.util.GradleVersion
 
 fun checkAndroidGradleVersion(project: Project) {
-    val androidGradlePlugin = getAndroidPluginVersion(project)
+    val androidGradlePlugin = getAndroidPlugin(project)
     if (androidGradlePlugin == null) {
         throw IllegalStateException(
             "The Android Gradle plugin not found. " +
@@ -44,7 +44,7 @@ fun checkMinimumGradleVersion() {
 private fun checkAndroidVersion(version: String?) =
     listOf("3.", "4.").any { version?.startsWith(it) ?: false }
 
-private fun getAndroidPluginVersion(project: Project): Dependency? =
+fun getAndroidPlugin(project: Project): Dependency? =
     findClassPathDependencyVersion(
         project,
         ANDROID_GRADLE_PLUGIN_GROUP,

--- a/src/test/kotlin/me/moallemi/gradle/advancedbuildversion/AdvancedBuildVersionPluginTest.kt
+++ b/src/test/kotlin/me/moallemi/gradle/advancedbuildversion/AdvancedBuildVersionPluginTest.kt
@@ -30,6 +30,8 @@ import io.mockk.slot
 import io.mockk.verifyOrder
 import me.moallemi.gradle.advancedbuildversion.AdvancedBuildVersionPlugin.Companion.EXTENSION_NAME
 import me.moallemi.gradle.advancedbuildversion.gradleextensions.AdvancedBuildVersionConfig
+import me.moallemi.gradle.advancedbuildversion.utils.ANDROID_GRADLE_PLUGIN_ATTRIBUTE_ID
+import me.moallemi.gradle.advancedbuildversion.utils.ANDROID_GRADLE_PLUGIN_GROUP
 import me.moallemi.gradle.advancedbuildversion.utils.checkAndroidGradleVersion
 import me.moallemi.gradle.advancedbuildversion.utils.checkMinimumGradleVersion
 import org.gradle.api.Action
@@ -96,6 +98,8 @@ class AdvancedBuildVersionPluginTest {
             every { applicationVariants } returns mockk()
         }
 
+        mockGetAndroidPlugin()
+
         plugin.apply(project)
 
         verifyOrder {
@@ -142,5 +146,33 @@ class AdvancedBuildVersionPluginTest {
             checkMinimumGradleVersion()
             checkAndroidGradleVersion(project)
         }
+    }
+
+    private fun mockGetAndroidPlugin() {
+        every { project.rootProject } returns mockk {
+            every { buildscript } returns mockk {
+                every { configurations } returns mockk {
+                    every {
+                        getByName("classpath").dependencies
+                    } returns mockk {
+                        every { iterator() } returns mockk()
+                        every { iterator().hasNext() } returns true
+                        every { iterator().next() } returns mockk {
+                            every { group } returns ANDROID_GRADLE_PLUGIN_GROUP
+                            every { name } returns ANDROID_GRADLE_PLUGIN_ATTRIBUTE_ID
+                            every { version } returns "3.0.1"
+                        }
+                    }
+                }
+            }
+        }
+        every {
+            project.buildscript.configurations.getByName("classpath").dependencies
+        } returns mockk {
+            every { iterator() } returns mockk()
+            every { iterator().hasNext() } returns false
+        }
+
+        every { project.plugins.hasPlugin(any<String>()) } returns true
     }
 }

--- a/src/test/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/AdvancedBuildVersionConfigTest.kt
+++ b/src/test/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/AdvancedBuildVersionConfigTest.kt
@@ -16,6 +16,7 @@
 
 package me.moallemi.gradle.advancedbuildversion.gradleextensions
 
+import com.android.build.gradle.AppExtension
 import groovy.lang.Closure
 import groovy.lang.GroovyShell
 import io.mockk.clearAllMocks
@@ -95,6 +96,14 @@ class AdvancedBuildVersionConfigTest {
     @Test
     fun `renameOutputApkIfPossible runs`() {
         config.renameOutputApkIfPossible(mockk())
+    }
+
+    @Test
+    fun `renameOutputApk runs`() {
+        every { project.extensions.findByType(AppExtension::class.java) } returns mockk {
+            every { applicationVariants } returns mockk()
+        }
+        config.renameOutputApk()
     }
 
     private fun givenProject() {


### PR DESCRIPTION
Android Gradle Plugin `4.1.0` [drops support](https://developer.android.com/studio/known-issues#variant_output) for renaming apk. We are using a workaround to keep renaming option for gradle-advanced-build-version library.

This PR resolves #46 