### PR TITLE
Add support for custom version code step

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ advancedVersioning {
  * `GIT_COMMIT_COUNT` will output total commits number in current branch
  * `DATE` formatted number e.g.: 1501101614
  * `AUTO_INCREMENT_DATE` will output 101101614
- * `AUTO_INCREMENT_ONE_STEP` will output e.g: 24. this
- property stores AI_VERSION_CODE in `version.properties` file in build.gradle directory, you may
- also change `dependsOnTasks` property to specify that on witch tasks should increase version code
+ * `AUTO_INCREMENT_ONE_STEP` will output e.g: 24
+ * `AUTO_INCREMENT_STEP` will output e.g: 26
+ 
+ `AUTO_INCREMENT_ONE_STEP` and `AUTO_INCREMENT_STEP` store AI_VERSION_CODE in `version.properties` file in build.gradle 
+ directory, you may also change `dependsOnTasks` property to specify that on witch tasks should increase version code
  (default is every task that contains 'release' in its name)
 
 ```groovy
@@ -136,6 +138,16 @@ advancedVersioning {
   }
 }
 ```
+
+`AUTO_INCREMENT_STEP` allows you to set a step different from 1:
+```groovy
+advancedVersioning {
+  codeOptions {
+    versionCodeType 'AUTO_INCREMENT_STEP'
+    versionCodeStep 2
+  }
+}
+``` 
 
 ## File output options
 You can also rename the output generated apk file with this plugin. it can be done just by enabling 

--- a/src/test/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/VersionCodeConfigTest.kt
+++ b/src/test/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/VersionCodeConfigTest.kt
@@ -24,6 +24,7 @@ import java.io.FileInputStream
 import java.util.Properties
 import junit.framework.TestCase.assertEquals
 import me.moallemi.gradle.advancedbuildversion.gradleextensions.VersionCodeType.AUTO_INCREMENT_ONE_STEP
+import me.moallemi.gradle.advancedbuildversion.gradleextensions.VersionCodeType.AUTO_INCREMENT_STEP
 import me.moallemi.gradle.advancedbuildversion.gradleextensions.VersionCodeType.GIT_COMMIT_COUNT
 import me.moallemi.gradle.advancedbuildversion.utils.GitWrapper
 import org.gradle.api.GradleException
@@ -177,6 +178,21 @@ class VersionCodeConfigTest {
         versionCodeConfig.increaseVersionCodeIfPossible()
 
         assertEquals(versionCodeConfig.versionCode, currentVersionCode)
+    }
+
+    @Test
+    fun `versionCodeType is AUTO_INCREMENT_STEP and versionCodeStep is 4`() {
+        versionFile.apply {
+            val versionProps = Properties()
+            versionProps.load(FileInputStream(this))
+            versionProps["AI_VERSION_CODE"] = "2"
+            versionProps.store(this.writer(), null)
+        }
+
+        versionCodeConfig.versionCodeType(AUTO_INCREMENT_STEP)
+        versionCodeConfig.versionCodeStep(4)
+
+        assertEquals(6, versionCodeConfig.versionCode)
     }
 
     companion object {


### PR DESCRIPTION
This PR adds support for the custom version code step.

To use custom step the user can now set the `versionCodeType` to `AUTO_INCREMENT_STEP` and define `versionCodeStep` value. Other options work the same as in `AUTO_INCREMENT_ONE_STEP`.

✅ Test added.
✅ README updated.