### PR TITLE
Fix and improve AUTO_INCREMENT_DATE

### DIFF
--- a/src/main/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/VersionCodeConfig.kt
+++ b/src/main/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/VersionCodeConfig.kt
@@ -25,9 +25,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import java.io.File
 import java.io.FileInputStream
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import java.time.Instant
 import java.util.Properties
 
 class VersionCodeConfig(
@@ -96,8 +94,7 @@ class VersionCodeConfig(
     }
 
     private fun byDateAutoIncrement(): Int {
-        val formatter = SimpleDateFormat("yyMMddHHmm", Locale.ENGLISH)
-        return formatter.format(Date()).toInt() - 1400000000
+        return (Instant.now().epochSecond - 1735689600).toInt() // 2025-01-01
     }
 
     private fun byGitCommitCount() = gitWrapper.getCommitsNumberInBranch()

--- a/src/test/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/VersionCodeConfigTest.kt
+++ b/src/test/kotlin/me/moallemi/gradle/advancedbuildversion/gradleextensions/VersionCodeConfigTest.kt
@@ -196,6 +196,15 @@ class VersionCodeConfigTest {
         assertEquals(6, versionCodeConfig.versionCode)
     }
 
+    @Test
+    fun `versionCodeType is AUTO_INCREMENT_DATE`() {
+        versionCodeConfig.versionCodeType(VersionCodeType.AUTO_INCREMENT_DATE)
+
+        // "The greatest value Google Play allows for versionCode is 2100000000."
+        // @see https://developer.android.com/studio/publish/versioning#appversioning
+        assert(versionCodeConfig.versionCode <= 2100000000)
+    }
+
     companion object {
         private val versionFilePath = getResourcePath().path + ""
 


### PR DESCRIPTION
This is a fix and improvement for `VersionCodeType.AUTO_INCREMENT_DATE`

### Exception

```
java.lang.NumberFormatException: For input string: "2503141020"
	at me.moallemi.gradle.advancedbuildversion.gradleextensions.VersionCodeConfig.byDateAutoIncrement(VersionCodeConfig.kt:100)
	at me.moallemi.gradle.advancedbuildversion.gradleextensions.VersionCodeConfig.getVersionCode(VersionCodeConfig.kt:68)
	at me.moallemi.gradle.advancedbuildversion.gradleextensions.AdvancedBuildVersionConfig$versionCode$2.invoke(AdvancedBuildVersionConfig.kt:39)
	at me.moallemi.gradle.advancedbuildversion.gradleextensions.AdvancedBuildVersionConfig$versionCode$2.invoke(AdvancedBuildVersionConfig.kt:38)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at me.moallemi.gradle.advancedbuildversion.gradleextensions.AdvancedBuildVersionConfig.getVersionCode(AdvancedBuildVersionConfig.kt:38)
...
```

### Improvement

Instead of date formatting and integer parsing, the implementation now uses `java.time.Instant` to work with the epoch timestamp. For the sake of future-proofing, the subtracted offset has been raised to 2025-01-01.

### Test

The additional unit test ensures that the generated `versionCode` matches [Google's requirements](https://developer.android.com/studio/publish/versioning#appversioning).